### PR TITLE
Improve dependency skipping in tests

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,46 @@
 
+# Virtual Try-On Telegram Bot
+
+This project provides a simple Telegram bot that performs virtual try-on using
+PyTorch. It automatically uses CUDA when available, so it will run on GPUs such
+as the NVIDIA RTX A4000.
+
+## Setup
+
+1. Create a Python environment and install dependencies:
+
+   ```bash
+   conda env create -f environment.yml
+   conda activate vton_bot
+   ```
+
+2. Set the required environment variables:
+
+   - `BOT_TOKEN` – token for your Telegram bot.
+   - `UNIFORMS` – JSON mapping uniform names to image paths.
+
+   Example `.env` file:
+
+   ```env
+   BOT_TOKEN=123456:ABCDEF
+   UNIFORMS={"Uniform 1": "static/uniforms/uniform1.png"}
+   ```
+
+## Running
+
+Launch the bot with:
+
+```bash
+python main.py
+```
+
+The result images will be saved next to the uploaded user photos.
+
+## Tests
+
+Install `pytest` (already included in the conda environment) and run:
+
+```bash
+pytest
+```
+

--- a/tests/test_vton.py
+++ b/tests/test_vton.py
@@ -1,0 +1,12 @@
+import pytest
+
+np = pytest.importorskip("numpy")
+torch = pytest.importorskip("torch", reason="torch is required for VTONPipeline")
+from vton import VTONPipeline
+
+
+def test_segment_size():
+    pipe = VTONPipeline()
+    img = np.zeros((64, 32, 3), dtype=np.uint8)
+    mask = pipe.segment(img)
+    assert mask.shape == img.shape[:2]

--- a/vton.py
+++ b/vton.py
@@ -16,6 +16,9 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+# Exported symbols for use from other modules
+__all__ = ["VTONPipeline", "process_vton", "virtual_try_on"]
+
 # ========== rembg fallback ==========
 try:
     from rembg import remove
@@ -100,7 +103,7 @@ class VTONPipeline:
         }
 
     def warp(self, cloth, mask, src_pts, dst_pts):
-        """PiecewiseAffine warp."""
+        """Piecewise-affine warp."""
         src = np.array([src_pts[k] for k in ["nose","left_shoulder","right_shoulder","left_hip","right_hip"]])
         dst = np.array([dst_pts[k] for k in ["nose","left_shoulder","right_shoulder","left_hip","right_hip"]])
         tfm = PiecewiseAffineTransform()
@@ -155,6 +158,11 @@ class VTONPipeline:
 
 def process_vton(person_path, cloth_path, output_path):
     return VTONPipeline().run(person_path, cloth_path, output_path)
+
+def virtual_try_on(person_path, cloth_path):
+    """Wrapper for easier use from external modules."""
+    out_path = os.path.join(os.path.dirname(person_path), "vton_result.jpg")
+    return process_vton(person_path, cloth_path, out_path)
 
 if __name__ == "__main__":
     # Пути


### PR DESCRIPTION
## Summary
- skip the segmentation test when numpy isn't available

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68556f755408832aa07c132241f13839