### PR TITLE
Remove unused pkg_resources import

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,7 +13,6 @@ from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
 from aiogram.types.input_file import FSInputFile
 from dotenv import load_dotenv
 from vton import virtual_try_on
-import pkg_resources
 
 # Load environment variables
 load_dotenv()


### PR DESCRIPTION
## Summary
- drop `pkg_resources` import from main.py

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68572816b194832a809311726a29513c