### PR TITLE
Handle missing BOT_TOKEN

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ import json
 import gc
 import psutil
 import torch
+import sys
 from aiogram import Bot, Dispatcher, types, F, __version__ as aiogram_version
 from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
@@ -25,6 +26,10 @@ logging.basicConfig(
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 )
 logger = logging.getLogger(__name__)
+
+if not BOT_TOKEN:
+    logger.error("BOT_TOKEN is not set. Exiting.")
+    sys.exit(1)
 
 # Memory monitoring function
 def log_memory_usage():


### PR DESCRIPTION
## Summary
- ensure `BOT_TOKEN` is present before creating the bot

## Testing
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68586569bd38832a9faf501a90a7d615