### PR TITLE
Use relative paths

### DIFF
--- a/collect_checkpoints.py
+++ b/collect_checkpoints.py
@@ -1,13 +1,23 @@
 import os
 import shutil
 import logging
+import argparse
+from pathlib import Path
 
 # Настройка логирования
 logging.basicConfig(level=logging.INFO, format='%(message)s')
 logger = logging.getLogger(__name__)
 
-# Целевая директория для копирования
-TARGET_DIR = "/root/bot/checkpoints_collected"
+# Целевая директория для копирования задаётся аргументом
+parser = argparse.ArgumentParser(description="Collect model checkpoints")
+parser.add_argument(
+    "--target-dir",
+    default=str(Path.cwd() / "checkpoints_collected"),
+    help="Directory to copy checkpoints into",
+)
+args = parser.parse_args()
+
+TARGET_DIR = args.target_dir
 os.makedirs(TARGET_DIR, exist_ok=True)
 
 # Список исходных путей (из вашего find)

--- a/vton.py
+++ b/vton.py
@@ -170,16 +170,32 @@ def virtual_try_on(person_path, cloth_path):
     return process_vton(person_path, cloth_path, out_path)
 
 if __name__ == "__main__":
-    # Пути
-    person = "/root/bot/temp_person_50007584.jpg"
-    cloth  = "/root/bot/static/uniforms/uniform1.png"
-    out    = "/root/bot/tmp/vton_result.jpg"
+    import argparse
+    from pathlib import Path
 
-    # Заглушки
-    for p in (person, cloth):
+    parser = argparse.ArgumentParser(description="Run a simple VTON example")
+    cwd = Path.cwd()
+    parser.add_argument(
+        "--person",
+        default=str(cwd / "temp_person_50007584.jpg"),
+        help="Path to the person image",
+    )
+    parser.add_argument(
+        "--cloth",
+        default=str(cwd / "static" / "uniforms" / "uniform1.png"),
+        help="Path to the cloth image",
+    )
+    parser.add_argument(
+        "--out",
+        default=str(cwd / "tmp" / "vton_result.jpg"),
+        help="Where to save the result image",
+    )
+    args = parser.parse_args()
+
+    for p in (args.person, args.cloth):
         os.makedirs(os.path.dirname(p), exist_ok=True)
         if not os.path.exists(p):
-            cv2.imwrite(p, np.zeros((1024,1024,3),dtype=np.uint8))
+            cv2.imwrite(p, np.zeros((1024, 1024, 3), dtype=np.uint8))
 
-    os.makedirs(os.path.dirname(out), exist_ok=True)
-    process_vton(person, cloth, out)
+    os.makedirs(os.path.dirname(args.out), exist_ok=True)
+    process_vton(args.person, args.cloth, args.out)


### PR DESCRIPTION
## Summary
- make collection script take a configurable `--target-dir`
- make vton example paths configurable and default to relative locations

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68586b22c64c832a8b6f826d284e0cbc