### PR TITLE
Make checkpoint dir configurable

### DIFF
--- a/collect_checkpoints.py
+++ b/collect_checkpoints.py
@@ -10,10 +10,11 @@ logger = logging.getLogger(__name__)
 
 # Целевая директория для копирования задаётся аргументом
 parser = argparse.ArgumentParser(description="Collect model checkpoints")
+DEFAULT_TARGET_DIR = os.environ.get("TARGET_DIR", "checkpoints_collected")
 parser.add_argument(
     "--target-dir",
-    default=str(Path.cwd() / "checkpoints_collected"),
-    help="Directory to copy checkpoints into",
+    default=DEFAULT_TARGET_DIR,
+    help="Directory to copy checkpoints into (or set TARGET_DIR env var)",
 )
 args = parser.parse_args()
 

--- a/readme.md
+++ b/readme.md
@@ -16,15 +16,25 @@ as the NVIDIA RTX A4000.
 
 2. Set the required environment variables:
 
-   - `BOT_TOKEN` – token for your Telegram bot.
-   - `UNIFORMS` – JSON mapping uniform names to image paths.
+    - `BOT_TOKEN` – token for your Telegram bot.
+    - `UNIFORMS` – JSON mapping uniform names to image paths.
+    - `TARGET_DIR` – _(optional)_ directory used by `collect_checkpoints.py`.
 
    Example `.env` file:
 
    ```env
    BOT_TOKEN=123456:ABCDEF
-   UNIFORMS={"Uniform 1": "static/uniforms/uniform1.png"}
+UNIFORMS={"Uniform 1": "static/uniforms/uniform1.png"}
+```
+
+3. *(Optional)* Gather pretrained checkpoints into a single directory:
+
+   ```bash
+   python collect_checkpoints.py
    ```
+
+   The script copies the various model files into `checkpoints_collected` by default.
+   Set the `TARGET_DIR` environment variable or pass `--target-dir` to change the location.
 
 ## Running
 


### PR DESCRIPTION
## Summary
- allow overriding checkpoint output folder via `TARGET_DIR` env var
- document the optional environment variable and how to gather checkpoints

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'vton')*
- `pip install torch --extra-index-url https://download.pytorch.org/whl/cpu` *(fails: cannot connect to download.pytorch.org)*

------
https://chatgpt.com/codex/tasks/task_e_68586dbca514832aa8e05cb44e73dee4