### PR TITLE
Clarify test env and skip heavy tests

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -62,9 +62,16 @@ uses that image automatically.
 
 ## Tests
 
-Install `pytest` (already included in the conda environment) and run:
+Running the tests requires the same Conda environment used by the bot. Make
+sure you create and activate it first:
 
 ```bash
+conda env create -f environment.yml
+conda activate vton_bot
 pytest
 ```
+
+If some of the heavy dependencies such as PyTorch are not available you can set
+`SKIP_HEAVY_TESTS=1` to run only the lightweight tests. Heavy tests will also be
+automatically skipped when the required packages are missing.
 

--- a/tests/test_vton.py
+++ b/tests/test_vton.py
@@ -1,10 +1,17 @@
+import os
 import numpy as np
-import cv2
 import pytest
+cv2 = pytest.importorskip("cv2")
 from vton import VTONPipeline
 
+# Skip heavy tests when requested or when heavy dependencies are missing.
+SKIP_HEAVY = os.getenv("SKIP_HEAVY_TESTS") == "1"
 
+
+@pytest.mark.skipif(SKIP_HEAVY, reason="Heavy tests are skipped")
 def test_segment_size():
+    pytest.importorskip("torch")
+    pytest.importorskip("torchvision")
     pipe = VTONPipeline()
     img = np.zeros((64, 32, 3), dtype=np.uint8)
     mask = pipe.segment(img)


### PR DESCRIPTION
## Summary
- document that tests rely on the Conda env from `environment.yml`
- allow skipping heavy tests when dependencies are missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859000753f8832aa7865c732e120da8