### PR TITLE
Fix default person filename

### DIFF
--- a/vton.py
+++ b/vton.py
@@ -177,7 +177,7 @@ if __name__ == "__main__":
     cwd = Path.cwd()
     parser.add_argument(
         "--person",
-        default=str(cwd / "temp_person_50007584.jpg"),
+        default=str(cwd / "temp_person.jpg"),
         help="Path to the person image",
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary
- set example's default person image to `temp_person.jpg`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685903d8d228832a9393fc6b1c7552fb