### PR TITLE
Replace pretrained flag in Keypoint R-CNN init

### DIFF
--- a/vton.py
+++ b/vton.py
@@ -40,7 +40,7 @@ class VTONPipeline:
 
         # Keypoint R-CNN for human pose (nose, shoulders, hips, etc.)
         self.pose_model = models.detection.keypointrcnn_resnet50_fpn(
-            pretrained=True
+            weights="DEFAULT"
         ).eval().to(self.device)
         logger.info("Keypoint R-CNN loaded.")
 


### PR DESCRIPTION
## Summary
- initialize Keypoint R-CNN with `weights="DEFAULT"`

## Testing
- `SKIP_HEAVY_TESTS=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6859085863fc832aa1186d7e6e686780