### PR TITLE
Use importorskip to import numpy in tests

### DIFF
--- a/tests/test_vton.py
+++ b/tests/test_vton.py
@@ -1,6 +1,6 @@
 import os
-import numpy as np
 import pytest
+np = pytest.importorskip("numpy")
 cv2 = pytest.importorskip("cv2")
 from vton import VTONPipeline
 


### PR DESCRIPTION
## Summary
- allow test suite to skip when numpy isn't installed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b16d051f4832a93cdfac217c47db9