### PR TITLE
Remove unused python-telegram-bot dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -286,7 +286,6 @@ dependencies:
       - pytest==8.4.1
       - python-dateutil==2.9.0.post0
       - python-dotenv==1.1.0
-      - python-telegram-bot==22.1
       - referencing==0.36.2
       - rembg==2.0.66
       - requests==2.32.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -79,7 +79,6 @@ pyparsing==3.2.3
 pytest==8.4.1
 python-dateutil==2.9.0.post0
 python-dotenv==1.1.0
-python-telegram-bot==22.1
 PyWavelets==1.8.0
 PyYAML==6.0.2
 referencing==0.36.2


### PR DESCRIPTION
## Summary
- drop python-telegram-bot from requirements and environment specs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b1a2a1518832a8ca6511704120b0e