### PR TITLE
Optimize VTON pipeline reuse

### DIFF
--- a/tests/test_vton.py
+++ b/tests/test_vton.py
@@ -34,3 +34,16 @@ def test_run_cloth_imread_failure(tmp_path):
     out = tmp_path / "out.jpg"
     with pytest.raises(RuntimeError, match="Failed to load cloth image"):
         pipe.run(str(person_path), "nonexistent.jpg", str(out))
+
+
+def test_get_pipeline_cache(monkeypatch):
+    from vton import get_pipeline
+
+    dummy = object()
+    monkeypatch.setattr("vton.VTONPipeline", lambda: dummy)
+    monkeypatch.setattr("vton._GLOBAL_PIPELINE", None)
+
+    first = get_pipeline()
+    second = get_pipeline()
+
+    assert first is second is dummy

--- a/vton.py
+++ b/vton.py
@@ -23,7 +23,12 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 # Exported symbols for use from other modules
-__all__ = ["VTONPipeline", "process_vton", "virtual_try_on"]
+__all__ = [
+    "VTONPipeline",
+    "process_vton",
+    "virtual_try_on",
+    "get_pipeline",
+]
 
 # ========== rembg fallback ==========
 try:
@@ -232,13 +237,27 @@ class VTONPipeline:
         logger.info(f"Saved result to {out_path}")
         return out_path
 
-def process_vton(person_path, cloth_path, output_path):
-    return VTONPipeline().run(person_path, cloth_path, output_path)
 
-def virtual_try_on(person_path, cloth_path):
-    """Wrapper for easier use from external modules."""
+_GLOBAL_PIPELINE = None
+
+
+def get_pipeline():
+    """Return a cached :class:`VTONPipeline` instance."""
+    global _GLOBAL_PIPELINE
+    if _GLOBAL_PIPELINE is None:
+        _GLOBAL_PIPELINE = VTONPipeline()
+    return _GLOBAL_PIPELINE
+
+def process_vton(person_path, cloth_path, output_path, pipeline=None):
+    """Run the virtual try-on pipeline."""
+    if pipeline is None:
+        pipeline = get_pipeline()
+    return pipeline.run(person_path, cloth_path, output_path)
+
+def virtual_try_on(person_path, cloth_path, pipeline=None):
+    """Convenience wrapper returning the output path of the result image."""
     out_path = os.path.join(os.path.dirname(person_path), "vton_result.jpg")
-    return process_vton(person_path, cloth_path, out_path)
+    return process_vton(person_path, cloth_path, out_path, pipeline=pipeline)
 
 if __name__ == "__main__":
     import argparse


### PR DESCRIPTION
## Summary
- allow caching of the heavy VTONPipeline
- expose `get_pipeline` and let `process_vton`/`virtual_try_on` reuse it
- test caching behaviour

## Testing
- `SKIP_HEAVY_TESTS=1 PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ba1c83e8c832abb6c4c89126cfe88