### PR TITLE
Add OpenPose build helper and protobuf notes

### DIFF
--- a/install_openpose_ubuntu.sh
+++ b/install_openpose_ubuntu.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build OpenPose with Python bindings on Ubuntu.
+# The script installs required dependencies, ensures protobuf headers are
+# available and builds OpenPose from source.
+
+sudo apt-get update
+sudo apt-get install -y build-essential cmake git libopencv-dev \
+    libgoogle-glog-dev libatlas-base-dev libprotobuf-dev protobuf-compiler
+
+# Some Ubuntu images may not ship the protobuf headers even after installing
+# libprotobuf-dev. OpenPose requires google/protobuf/runtime_version.h.
+if ! grep -q "runtime_version.h" -r /usr/include/google/protobuf 2>/dev/null; then
+    echo "protobuf headers missing; building protobuf from source"
+    # Match the version to the installed runtime library.
+    proto_ver=$(protoc --version | awk '{print $2}')
+    wget -q https://github.com/protocolbuffers/protobuf/releases/download/v${proto_ver}/protobuf-cpp-${proto_ver}.tar.gz
+    tar -xzf protobuf-cpp-${proto_ver}.tar.gz
+    cd protobuf-${proto_ver}
+    ./configure
+    make -j"$(nproc)"
+    sudo make install
+    sudo ldconfig
+    cd ..
+fi
+
+# Clone and build OpenPose
+if [ ! -d openpose ]; then
+    git clone --depth 1 https://github.com/CMU-Perceptual-Computing-Lab/openpose.git
+fi
+cd openpose
+git submodule update --init --recursive
+mkdir -p build && cd build
+cmake -DBUILD_PYTHON=ON -DBUILD_EXAMPLES=OFF ..
+make -j"$(nproc)"
+# The Python module will be available under build/python.
+

--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,10 @@ UNIFORMS={"Uniform 1": "static/uniforms/uniform1.png"}
    CatVTON and VITON-HD checkpoints are provided in their respective repositories.
    Place the downloaded files at the paths listed in the table below.
 
-4. *(Optional)* Gather pretrained checkpoints into a single directory:
+4. *(Optional)* Build the OpenPose Python module. Ensure that the system package providing `google/protobuf/runtime_version.h` (`libprotobuf-dev` on Ubuntu) is installed. If it is missing or unavailable, compile protobuf from source so that its version matches the installed runtime library. Once this prerequisite is met, run `install_openpose_ubuntu.sh` from the repository root.
+
+
+5. *(Optional)* Gather pretrained checkpoints into a single directory:
 
    ```bash
    python collect_checkpoints.py


### PR DESCRIPTION
## Summary
- provide install_openpose_ubuntu.sh to compile OpenPose and ensure protobuf headers
- document protobuf requirement and script usage in README

## Testing
- `pip install numpy`
- `SKIP_HEAVY_TESTS=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d54b0145c832ab5dbeb44569fc320