### PR TITLE
Fix protobuf version mismatch in OpenPose install script

### DIFF
--- a/install_openpose_ubuntu.sh
+++ b/install_openpose_ubuntu.sh
@@ -3,21 +3,27 @@ set -euo pipefail
 
 # Build OpenPose with Python bindings on Ubuntu.
 # The script installs required dependencies, ensures protobuf headers are
-# available and builds OpenPose from source.
+# available and builds OpenPose from source with matching protobuf versions.
 
 sudo apt-get update
+
+# Discover the candidate protobuf version available from APT.
+proto_pkg_ver=$(apt-cache policy libprotobuf-dev | awk '/Candidate:/ {print $2}')
+
 sudo apt-get install -y build-essential cmake git libopencv-dev \
-    libgoogle-glog-dev libatlas-base-dev libprotobuf-dev protobuf-compiler
+    libgoogle-glog-dev libatlas-base-dev \
+    "libprotobuf-dev=${proto_pkg_ver}" "protobuf-compiler=${proto_pkg_ver}"
+
+# Extract upstream version (strip epoch and revision) for source builds.
+proto_src_ver=$(echo "$proto_pkg_ver" | cut -d'-' -f1 | cut -d':' -f2)
 
 # Some Ubuntu images may not ship the protobuf headers even after installing
 # libprotobuf-dev. OpenPose requires google/protobuf/runtime_version.h.
 if ! grep -q "runtime_version.h" -r /usr/include/google/protobuf 2>/dev/null; then
     echo "protobuf headers missing; building protobuf from source"
-    # Match the version to the installed runtime library.
-    proto_ver=$(protoc --version | awk '{print $2}')
-    wget -q https://github.com/protocolbuffers/protobuf/releases/download/v${proto_ver}/protobuf-cpp-${proto_ver}.tar.gz
-    tar -xzf protobuf-cpp-${proto_ver}.tar.gz
-    cd protobuf-${proto_ver}
+    wget -q "https://github.com/protocolbuffers/protobuf/releases/download/v${proto_src_ver}/protobuf-cpp-${proto_src_ver}.tar.gz"
+    tar -xzf protobuf-cpp-${proto_src_ver}.tar.gz
+    cd protobuf-${proto_src_ver}
     ./configure
     make -j"$(nproc)"
     sudo make install


### PR DESCRIPTION
## Summary
- lock libprotobuf version with apt
- build protobuf from source if headers are missing using the same version
- update OpenPose install steps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e99ba4d30832a8b565183162ffd04