### PR TITLE
Improve OpenPose install

### DIFF
--- a/install_openpose_ubuntu.sh
+++ b/install_openpose_ubuntu.sh
@@ -25,6 +25,9 @@ else
         "libprotobuf-dev=${proto_pkg_ver}" "protobuf-compiler=${proto_pkg_ver}"
 fi
 
+# Report which protoc will be used and its version
+echo "Using protoc: $(which protoc) ($(protoc --version || echo unknown))"
+
 # Extract upstream version (strip epoch and revision) for source builds.
 proto_src_ver=$(echo "$proto_pkg_ver" | cut -d'-' -f1 | cut -d':' -f2)
 
@@ -49,7 +52,8 @@ fi
 cd openpose
 git submodule update --init --recursive
 mkdir -p build && cd build
-cmake -DBUILD_PYTHON=ON -DBUILD_EXAMPLES=OFF ..
+cmake -DBUILD_PYTHON=ON -DBUILD_EXAMPLES=OFF \
+    -DPROTOBUF_PROTOC_EXECUTABLE=/usr/bin/protoc ..
 make -j"$(nproc)"
 # Install the library system-wide and expose the Python module globally.
 sudo make install

--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,22 @@ UNIFORMS={"Uniform 1": "static/uniforms/uniform1.png"}
    Create the `pytorch-openpose/model/` directory if it does not already exist, and
    place the other model files under `models/` as listed in the table below.
 
-4. *(Optional)* Build the OpenPose Python module. Ensure that the system package providing `google/protobuf/runtime_version.h` (`libprotobuf-dev` on Ubuntu) is installed. If it is missing or unavailable, compile protobuf from source so that its version matches the installed runtime library. Once this prerequisite is met, run `install_openpose_ubuntu.sh` from the repository root. After the build completes, run `sudo make install` and then `python3 -m pip install -e python` inside the `pytorch-openpose` directory. This installs the Python bindings required for `VTONPipeline` to load OpenPose.
+4. *(Optional)* Build the OpenPose Python module. Ensure that the system package
+   providing `google/protobuf/runtime_version.h` (`libprotobuf-dev` on Ubuntu) is
+   installed. The compiler (`protoc`) must come from the same package version as
+   the library; check with `which protoc` and `protoc --version` (Ubuntu 22.04
+   ships 3.12.4). If a Conda environment shadows `/usr/bin/protoc`, override it
+   when running CMake:
+
+   ```bash
+   cmake .. -DPROTOBUF_PROTOC_EXECUTABLE=/usr/bin/protoc
+   ```
+
+   Once the prerequisite headers are present, run `install_openpose_ubuntu.sh`
+   from the repository root. After the build completes, run `sudo make install`
+   and then `python3 -m pip install -e python` inside the `pytorch-openpose`
+   directory. This installs the Python bindings required for `VTONPipeline` to
+   load OpenPose.
 
 
 5. *(Optional)* Gather pretrained checkpoints into a single directory:


### PR DESCRIPTION
## Summary
- ensure OpenPose uses system protoc during cmake
- document protoc version checks in README

## Testing
- `SKIP_HEAVY_TESTS=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685bbe79bab0832a88ae69a595e1b1e4