### PR TITLE
Enable env config for OpenPose weights

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,10 @@ UNIFORMS={"Uniform 1": "static/uniforms/uniform1.png"}
    ```
 
    Create the `pytorch-openpose/model/` directory if it does not already exist, and
-   place the other model files under `models/` as listed in the table below.
+   place the other model files under `models/` as listed in the table below. If you
+   store the OpenPose weights elsewhere, set the `OPENPOSE_MODEL_DIR` environment
+   variable to the directory containing `body_pose_model.pth` so that
+   `VTONPipeline` can locate them.
 
 4. *(Optional)* Build the OpenPose Python module. Ensure that the system package
    providing `google/protobuf/runtime_version.h` (`libprotobuf-dev` on Ubuntu) is

--- a/vton.py
+++ b/vton.py
@@ -71,10 +71,12 @@ class VTONPipeline:
 
         # Attempt to use OpenPose BODY_25 for pose estimation. The model
         # weights are referenced relative to the repository root, matching
-        # the paths used in collect_checkpoints.py. If OpenPose or its
-        # weights are unavailable, fall back to Mediapipe.
-        self.openpose_body = Path("pytorch-openpose/model/body_pose_model.pth")
-        self.openpose_hand = Path("pytorch-openpose/model/hand_pose_model.pth")
+        # the paths used in collect_checkpoints.py. The directory can be
+        # overridden with the ``OPENPOSE_MODEL_DIR`` environment variable.
+        # If OpenPose or its weights are unavailable, fall back to Mediapipe.
+        model_dir = Path(os.environ.get("OPENPOSE_MODEL_DIR", "pytorch-openpose/model"))
+        self.openpose_body = model_dir / "body_pose_model.pth"
+        self.openpose_hand = model_dir / "hand_pose_model.pth"
         self.pose_backend = "mediapipe"
         try:  # pragma: no cover - optional heavy deps
             from openpose import pyopenpose as op  # type: ignore


### PR DESCRIPTION
## Summary
- allow setting `OPENPOSE_MODEL_DIR` to override the OpenPose weight path
- document the new variable in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685fdfb30130832aaccb43b3d2c0c2b5