### PR TITLE
Fix openpose model path and ignore pytest cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ tmp/
 *.pyc
 temp_person_*.jpg
 temp_person.jpg
+.pytest_cache/

--- a/vton.py
+++ b/vton.py
@@ -76,8 +76,11 @@ class VTONPipeline:
         try:  # pragma: no cover - optional heavy deps
             from openpose import pyopenpose as op  # type: ignore
 
+            model_dir = os.environ.get("OPENPOSE_MODEL_DIR")
+            if model_dir is None:
+                model_dir = str(Path(__file__).resolve().parent / "openpose" / "models")
             params = {
-                "model_folder": str(Path(__file__).resolve().parent / "openpose" / "models"),
+                "model_folder": model_dir,
                 "model_pose": "BODY_25",
             }
             self.op = op


### PR DESCRIPTION
## Summary
- allow overriding OpenPose model directory using the `OPENPOSE_MODEL_DIR` environment variable
- ignore `.pytest_cache`

## Testing
- `SKIP_HEAVY_TESTS=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686289e7a334832abde3888eba896c98