### PR TITLE
Fix mp.Image usage

### DIFF
--- a/vton.py
+++ b/vton.py
@@ -198,7 +198,10 @@ class VTONPipeline:
 
     def _extract_keypoints_mp(self, img: np.ndarray):
         """Mediapipe-based keypoint extraction."""
-        results = self.mp_pose.process(cv2.cvtColor(img, cv2.COLOR_BGR2RGB))
+        mp_image = self.mp.Image(
+            image_format=self.mp.ImageFormat.SRGB, data=img[..., ::-1]
+        )
+        results = self.mp_pose.process(mp_image)
         lm = results.pose_landmarks
         if not lm:
             return None


### PR DESCRIPTION
## Summary
- convert numpy arrays to `mp.Image` when extracting keypoints
- keep Mediapipe `Pose` initialization in `__init__`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68638c10f668832a83a53405b2ae87d2