### PR TITLE
Fix Mediapipe Image creation

### DIFF
--- a/vton.py
+++ b/vton.py
@@ -199,7 +199,7 @@ class VTONPipeline:
     def _extract_keypoints_mp(self, img: np.ndarray):
         """Mediapipe-based keypoint extraction."""
         mp_image = self.mp.Image(
-            image_format=self.mp.ImageFormat.SRGB, data=img[..., ::-1]
+            self.mp.ImageFormat.SRGB, img[..., ::-1].copy()
         )
         results = self.mp_pose.process(mp_image)
         lm = results.pose_landmarks


### PR DESCRIPTION
## Summary
- ensure mediapipe images are created with positional arguments
- run tests

## Testing
- `PYTHONPATH=$(pwd) pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68639e57d2d8832abf0c7d07c75f9202