### PR TITLE
Fix mediapipe process call

### DIFF
--- a/vton.py
+++ b/vton.py
@@ -201,7 +201,7 @@ class VTONPipeline:
         mp_image = self.mp.Image(
             self.mp.ImageFormat.SRGB, img[..., ::-1].copy()
         )
-        results = self.mp_pose.process(mp_image)
+        results = self.mp_pose.process(mp_image.numpy_view())
         lm = results.pose_landmarks
         if not lm:
             return None


### PR DESCRIPTION
## Summary
- call `process` on Mediapipe image's numpy view

## Testing
- `SKIP_HEAVY_TESTS=1 python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863a16d994c832a8315b07fadc3c567