### PR TITLE
Improve fallback logging

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -64,9 +64,11 @@ as the NVIDIA RTX A4000.
    and then `python3 -m pip install -e python` inside the `openpose`
    directory. This installs the Python bindings required for `VTONPipeline` to
    load OpenPose. If OpenPose is installed but fails to produce keypoints for an
-   image, the pipeline will automatically fall back to Mediapipe when it is
-   available. Installing Mediapipe is therefore recommended to avoid errors like
-   `Keypoint extraction failed` when OpenPose struggles with a particular photo.
+   image, you will see a warning like `OpenPose detected no keypoints on
+   (480, 640, 3); switching to Mediapipe` and the pipeline will automatically
+   fall back to Mediapipe when it is available. Installing Mediapipe is
+   therefore recommended to avoid errors like `Keypoint extraction failed` when
+   OpenPose struggles with a particular photo.
 
 
 5. *(Optional)* Gather pretrained checkpoints into a single directory:

--- a/tests/test_vton.py
+++ b/tests/test_vton.py
@@ -59,7 +59,7 @@ def test_invalid_segmentation_model():
         VTONPipeline(segmentation_model="foo")
 
 
-def test_extract_keypoints_fallback(monkeypatch):
+def test_extract_keypoints_fallback(monkeypatch, caplog):
     pipe = VTONPipeline.__new__(VTONPipeline)
     pipe.pose_backend = "openpose"
     pipe.op = type("Op", (), {"Datum": lambda self=None: type("Datum", (), {})(),
@@ -80,7 +80,9 @@ def test_extract_keypoints_fallback(monkeypatch):
     datum.poseKeypoints = None
     monkeypatch.setattr(pipe.op, "Datum", lambda: datum)
 
-    result = pipe.extract_keypoints(np.zeros((1, 1, 3), dtype=np.uint8))
+    with caplog.at_level(logging.WARNING):
+        result = pipe.extract_keypoints(np.zeros((1, 1, 3), dtype=np.uint8))
+    assert "no keypoints" in caplog.text.lower()
     assert fallback_called
     assert result == {"nose": (0, 0)}
 

--- a/vton.py
+++ b/vton.py
@@ -160,7 +160,14 @@ class VTONPipeline:
             pts_arr = datum.poseKeypoints
             if pts_arr is None or pts_arr.size == 0:
                 if self.mp_pose is not None:
-                    logger.warning("OpenPose failed, falling back to Mediapipe")
+                    backend_name = (
+                        "OpenPose" if self.pose_backend == "openpose" else self.pose_backend
+                    )
+                    logger.warning(
+                        "%s detected no keypoints on %s; switching to Mediapipe",
+                        backend_name,
+                        img.shape,
+                    )
                     return self._extract_keypoints_mp(img)
                 return None
             kp = pts_arr[0]


### PR DESCRIPTION
## Summary
- log the pose backend name and image shape when OpenPose returns no keypoints
- describe the warning in the README
- test that the warning is emitted when falling back to Mediapipe

## Testing
- `PYTHONPATH=$(pwd) pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863a79aecc8832a938d2680520e083c