### PR TITLE
Improve warp diagnostics

### DIFF
--- a/tests/test_vton.py
+++ b/tests/test_vton.py
@@ -96,10 +96,14 @@ def test_warp_fallback_estimation(monkeypatch, caplog):
 
     monkeypatch.setattr(PiecewiseAffineTransform, "estimate", lambda self, s, d: False)
     with caplog.at_level(logging.WARNING):
-        out_c, out_m = pipe.warp(cloth, mask, src, dst, person_shape=(4, 4))
+        out_c, out_m, status = pipe.warp(
+            cloth, mask, src, dst, person_shape=(4, 4), return_status=True
+        )
     assert out_c.shape == cloth.shape
     assert out_m.shape == mask.shape
+    assert status == "estimation_failed"
     assert "approximate overlay" in caplog.text.lower()
+    assert "3 src/3 dst" in caplog.text
 
 
 def test_warp_fallback_error(monkeypatch, caplog):
@@ -118,7 +122,10 @@ def test_warp_fallback_error(monkeypatch, caplog):
     )
 
     with caplog.at_level(logging.WARNING):
-        out_c, out_m = pipe.warp(cloth, mask, src, dst, person_shape=(4, 4))
+        out_c, out_m, status = pipe.warp(
+            cloth, mask, src, dst, person_shape=(4, 4), return_status=True
+        )
     assert out_c.shape == cloth.shape
     assert out_m.shape == mask.shape
+    assert status == "error"
     assert "approximate overlay" in caplog.text.lower()


### PR DESCRIPTION
## Summary
- log source/dest keypoint count when warp estimation fails
- add optional status return value from `warp`
- test new diagnostics and status codes

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863a8b6841c832abcf946f336a6d43d