### PR TITLE
Improve Mediapipe compatibility

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -70,6 +70,10 @@ as the NVIDIA RTX A4000.
    therefore recommended to avoid errors like `Keypoint extraction failed` when
    OpenPose struggles with a particular photo.
 
+   Mediapipe 0.10 changed the Pose API to use `mp.Image` objects instead of
+   plain NumPy arrays. `VTONPipeline` detects the supported input type at runtime
+   so either version will work.
+
 
 5. *(Optional)* Gather pretrained checkpoints into a single directory:
 


### PR DESCRIPTION
## Summary
- support both `mp.Image` and ndarray for Mediapipe pose
- document Mediapipe version differences in README
- test both code paths for keypoint extraction

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863bdef7ca4832a8a66d97599e0ab74