### PR TITLE
Improve warp failure logging

### DIFF
--- a/tests/test_vton.py
+++ b/tests/test_vton.py
@@ -103,7 +103,7 @@ def test_warp_fallback_estimation(monkeypatch, caplog):
     assert out_m.shape == mask.shape
     assert status == "estimation_failed"
     assert "approximate overlay" in caplog.text.lower()
-    assert "3 src/3 dst" in caplog.text
+    assert "3 source" in caplog.text and "3 destination" in caplog.text
 
 
 def test_warp_fallback_error(monkeypatch, caplog):

--- a/vton.py
+++ b/vton.py
@@ -392,7 +392,7 @@ class VTONPipeline:
         try:
             if not tfm.estimate(src, dst):
                 logger.warning(
-                    "Warp estimation failed with %d src/%d dst points. Using approximate overlay.",
+                    "Warp estimation failed with %d source and %d destination points. Using approximate overlay.",
                     len(src),
                     len(dst),
                 )


### PR DESCRIPTION
## Summary
- log source and destination point counts when warp estimation fails
- verify updated logging in warp fallback tests

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863c30b1f50832aab40199f475c3712