### PR TITLE
Fix mediapipe process call

### DIFF
--- a/tests/test_vton.py
+++ b/tests/test_vton.py
@@ -151,8 +151,8 @@ def test_extract_keypoints_mp_new_api(monkeypatch):
 
     calls = []
 
-    def process(self, arg):
-        calls.append(arg)
+    def process(self, arg, **kwargs):
+        calls.append((arg, kwargs))
         return type("Res", (), {"pose_landmarks": None})()
 
     pipe.mp = mp_stub
@@ -161,7 +161,8 @@ def test_extract_keypoints_mp_new_api(monkeypatch):
     img = np.zeros((2, 2, 3), dtype=np.uint8)
     assert pipe._extract_keypoints_mp(img) is None
     assert len(calls) == 1
-    assert isinstance(calls[0], FakeImage)
+    assert isinstance(calls[0][0], FakeImage)
+    assert calls[0][1]["image_size"] == (2, 2)
 
 
 def test_extract_keypoints_mp_fallback(monkeypatch):
@@ -186,8 +187,8 @@ def test_extract_keypoints_mp_fallback(monkeypatch):
         def __init__(self):
             self.calls = []
 
-        def process(self, arg):
-            self.calls.append(arg)
+        def process(self, arg, **kwargs):
+            self.calls.append((arg, kwargs))
             if isinstance(arg, FakeImage):
                 raise AttributeError("object has no attribute 'shape'")
             return type("Res", (), {"pose_landmarks": None})()
@@ -199,5 +200,6 @@ def test_extract_keypoints_mp_fallback(monkeypatch):
     img = np.zeros((2, 2, 3), dtype=np.uint8)
     assert pipe._extract_keypoints_mp(img) is None
     assert len(pose.calls) == 2
-    assert isinstance(pose.calls[0], FakeImage)
-    assert isinstance(pose.calls[1], np.ndarray)
+    assert isinstance(pose.calls[0][0], FakeImage)
+    assert pose.calls[0][1]["image_size"] == (2, 2)
+    assert isinstance(pose.calls[1][0], np.ndarray)

--- a/vton.py
+++ b/vton.py
@@ -206,6 +206,7 @@ class VTONPipeline:
         # Mediapipe expects images in RGB order. Convert from BGR before
         # constructing the ``mp.Image`` instance to avoid orientation issues.
         rgb = img[..., ::-1].copy()
+        h, w = img.shape[:2]
 
         # ``self.mp_pose.process`` changed in Mediapipe 0.10 to accept
         # ``mp.Image`` instead of ``np.ndarray``. Try the new API first and
@@ -214,7 +215,7 @@ class VTONPipeline:
             mp_image = self.mp.Image(
                 image_format=self.mp.ImageFormat.SRGB, data=rgb
             )
-            results = self.mp_pose.process(mp_image)
+            results = self.mp_pose.process(mp_image, image_size=(w, h))
         except AttributeError as e:
             if "shape" not in str(e):
                 raise


### PR DESCRIPTION
## Summary
- specify the input image size when calling Mediapipe
- adjust unit tests for the new call signature

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863e439d29c832aa4ffca13c0134bef